### PR TITLE
feat: 移动端样式优化

### DIFF
--- a/src/pages/index.less
+++ b/src/pages/index.less
@@ -24,6 +24,8 @@ body {
 }
 
 .mobile-sider {
+  height: unset !important;
+
   .sider-trigger {
     position: fixed;
     top: -26px - @footer-height;
@@ -34,8 +36,15 @@ body {
   }
 
   // 移动端下重新 drawer 样式
-  .ant-drawer-content {
-    overflow: unset;
+  .ant-drawer-mask {
+    display: none;
+  }
+  .ant-drawer-content-wrapper {
+    height: 50vh !important;
+  
+    .ant-drawer-content {
+      overflow: unset;
+    }
   }
   // 重写 drawer 开启时的样式
   &.ant-drawer-open {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -108,7 +108,7 @@ const Page = () => {
               visible={configPanelCollapse}
               forceRender
               placement="bottom"
-              closable={false}
+              closable
               className="mobile-sider"
               onClose={() => setConfigPanelCollapse(false)}
             >


### PR DESCRIPTION
移动端央视优化
1、去掉蒙层，开启`closeable`
2、抽屉占`50%`视窗高度

效果如下

![移动端优化](https://user-images.githubusercontent.com/24318174/117231823-9547e400-ae52-11eb-9ce6-294cc8b6de23.gif)
